### PR TITLE
Remove Secrets 

### DIFF
--- a/src/main/java/com/app/flight/AmadeusConnect.java
+++ b/src/main/java/com/app/flight/AmadeusConnect.java
@@ -16,7 +16,7 @@ enum AmadeusConnect {
     private Amadeus amadeus;
     private AmadeusConnect() {
         this.amadeus = Amadeus
-            .builder("LJ7RU9Uoc8SGWFdoatoqSrK4Fa6yMGVj", "J8ZTyEkMjP7sAD1p")
+            .builder("AMADEUS_CLIENT_ID", "AMADEUS_CLIENT_SECRET")
             .build();
     }
 


### PR DESCRIPTION
I would suggest removing the API key and API secret from the code and also revoke them, in case you haven't done already, as anyone can use them.

Instead, in the README it could be mentioned for developers to user their own keys. 